### PR TITLE
docs: add issue template for hosting request

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-hosting-request.md
+++ b/.github/ISSUE_TEMPLATE/4-hosting-request.md
@@ -11,7 +11,7 @@ about: I want to host my repo in keptn-sandbox
 ### Checklist
 - [ ] Repository transfer: <your-repo-here>
 - [ ] GitHub access permissions
-- [ ] Integration author has followed the [hosting guide](https://github.com/keptn-sandbox/contributing/blob/master/CONTRIBUTING.md) 
+- [ ] Repository author has followed the [hosting guide](https://github.com/keptn-sandbox/contributing/blob/master/CONTRIBUTING.md) 
 
 ### Sponsors
   

--- a/.github/ISSUE_TEMPLATE/4-hosting-request.md
+++ b/.github/ISSUE_TEMPLATE/4-hosting-request.md
@@ -6,7 +6,7 @@ about: I want to host my repo in keptn-sandbox
 
 ### Description
 
-<!-- Some context around your integration here -->
+<!-- Some context around your repo here -->
 
 ### Checklist
 - [ ] Repository transfer: <your-repo-here>

--- a/.github/ISSUE_TEMPLATE/4-hosting-request.md
+++ b/.github/ISSUE_TEMPLATE/4-hosting-request.md
@@ -1,7 +1,7 @@
 ---
 name: ":cloud: Hosting request"
 labels: hosting-request
-about: I want to host my integration in keptn-sandbox
+about: I want to host my repo in keptn-sandbox
 ---
 
 ### Description

--- a/.github/ISSUE_TEMPLATE/4-hosting-request.md
+++ b/.github/ISSUE_TEMPLATE/4-hosting-request.md
@@ -1,0 +1,20 @@
+---
+name: ":cloud: Hosting request"
+labels: hosting-request
+about: I want to host my integration in keptn-sandbox
+---
+
+### Description
+
+<!-- Some context around your integration here -->
+
+### Checklist
+- [ ] Repository transfer: <your-repo-here>
+- [ ] GitHub access permissions
+- [ ] Integration author has followed the [hosting guide](https://github.com/keptn-sandbox/contributing/blob/master/CONTRIBUTING.md) 
+
+### Sponsors
+  
+### References
+
+<!-- Link related issues and materials here -->


### PR DESCRIPTION
### Problem
We don't have an issue template for hosting request. This means we don't have a standard format for creating a hosting request issue. 

![image](https://user-images.githubusercontent.com/34534103/167560773-553c4c80-7f4a-4992-81e9-9a48bd41a642.png)


### Solution
Add a hosting template based on https://github.com/keptn-sandbox/contributing/issues/8